### PR TITLE
Iris 1.5.0 Hotfix Before Release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Upload Plugin Jar
         uses: actions/upload-artifact@v4
         with:
-          name: voiidcountdown-plugin
+          name: voiidcountdown-full
           path: voiidcountdown-plugin/target/*.jar
 
   buildDatapack:
@@ -39,10 +39,10 @@ jobs:
       - name: Zip Datapack
         run: |
           cd voiidcountdown-datapack
-          zip -r ../voiidcountdown-datapack.zip .
+          zip -r ../voiidcountdown-lite.zip .
 
       - name: Upload Datapack Zip
         uses: actions/upload-artifact@v4
         with:
-          name: voiidcountdown-datapack
-          path: voiidcountdown-datapack.zip
+          name: voiidcountdown-lite
+          path: voiidcountdown-lite.zip

--- a/voiidcountdown-datapack/data/vct/function/internal/api/uninstall.mcfunction
+++ b/voiidcountdown-datapack/data/vct/function/internal/api/uninstall.mcfunction
@@ -2,5 +2,5 @@
 
 bossbar remove voiidtimer:bar
 scoreboard objectives remove Timer
-datapack disable "file/voiidcountdown-datapack.zip"
-datapack disable "file/voiidcountdown-datapack"
+datapack disable "file/voiidcountdown-lite.zip"
+datapack disable "file/voiidcountdown-lite"

--- a/voiidcountdown-datapack/data/vct/functions/internal/api/uninstall.mcfunction
+++ b/voiidcountdown-datapack/data/vct/functions/internal/api/uninstall.mcfunction
@@ -2,5 +2,5 @@
 
 bossbar remove voiidtimer:bar
 scoreboard objectives remove Timer
-datapack disable "file/voiidcountdown-datapack.zip"
-datapack disable "file/voiidcountdown-datapack"
+datapack disable "file/voiidcountdown-lite.zip"
+datapack disable "file/voiidcountdown-lite"


### PR DESCRIPTION
Updated GitHub Actions workflow and uninstall scripts to use 'voiidcountdown-lite' instead of 'voiidcountdown-datapack' for artifact names and datapack references. This improves clarity between plugin and datapack variants.